### PR TITLE
Fix array index

### DIFF
--- a/recursive_graph_bisection.hpp
+++ b/recursive_graph_bisection.hpp
@@ -287,7 +287,7 @@ move_gains_t compute_move_gains(partition_t& P, size_t num_queries)
             }
             if (deg1[q]) {
                 left2right[q] = (deg1[q] - 1) * logn1 - (deg1[q] - 1) * fdata[0]
-                    + (deg2[q] + 1) * logn2 - (deg2[q] + 1) * fdata[4];
+                    + (deg2[q] + 1) * logn2 - (deg2[q] + 1) * fdata[5];
             }
             if (deg2[q])
                 right2left[q] = (deg1[q] + 1) * logn1 - (deg1[q] + 1) * fdata[2]


### PR DESCRIPTION
I think the deg1 calc should use fdata[5] (log(deg2[q] + 2) instead. This takes us back to 6.14 BPI on the sample index.