### PR TITLE
Fix in swapping empty docs

### DIFF
--- a/recursive_graph_bisection.hpp
+++ b/recursive_graph_bisection.hpp
@@ -161,6 +161,15 @@ bipartite_graph construct_bipartite_graph(
         size_t num_empty = 0;
         while (itr != ritr) {
             if (itr->num_terms == 0) {
+                // Find next non-empty doc from end
+                while(ritr->num_terms == 0 && ritr != itr) {
+                    num_empty++;
+                    --ritr;
+                }
+                // Ensure we did not meet itr
+                if (itr == ritr) {
+                    break;   
+                }
                 num_empty++;
                 swap_nodes(&*itr, &*ritr);
                 --ritr;


### PR DESCRIPTION
This is a real corner-case, but there is a potential situation where we swap two documents with size 0, meaning we keep empty docs in the bisection.